### PR TITLE
Adding Logstash JSON encoder and its dependencies.

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,9 +223,9 @@ can be found in conf/logback.xml from github [releases] (https://github.com/tomc
 
 ## Tomcat Customization ##
 
-#### Tomcat 9.0.x ####
+#### Tomcat 10.0.x ####
 
-After unpacking `apache-tomcat-9.0.x.zip` one can run Tomcat by executing `$CATALINA_HOME/bin/startup.sh`. This will cause running
+After unpacking `apache-tomcat-10.0.x.zip` one can run Tomcat by executing `$CATALINA_HOME/bin/startup.sh`. This will cause running
 Tomcat with standard java.util.logging enabled. The standard command line is:
 
     "java" \

--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ Configuration of logback-access doesn't require renamed packages, as the require
 _common class loader_.
 
 Sample `logback.xml` reflecting the configuration from standard `$CATALINA_HOME/conf/logging.properties`
-can be found in conf/logback.xml from github [releases] (https://github.com/tomcat-slf4j-logback/tomcat-slf4j-logback/releases).
+can be found in conf/logback.xml from github [releases](https://github.com/tomcat-slf4j-logback/tomcat-slf4j-logback/releases).
 
 
 ## Tomcat Customization ##

--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ This project's main and only goal is to allow the following:
   of logback-access,
 * make possible to use independent configuration of slf4j+logback from all web applications which may carry
   their own slf4j-api, logback-core, and logback-classic in their `WEB-INF/lib` directory.
+* make possible to use [`logstash-logback-encoder`](https://github.com/logfellow/logstash-logback-encoder) for logging in JSON format
 
 Using only Mavens `pom.xml` file, proper source JARs are downloaded from maven repository and unpacked.
 Then all classes are refactored under `org.apache.juli.logging` package/subpackages and then compiled.
@@ -197,6 +198,17 @@ config file, e.g.:
                 additivity="false">
             <appender-ref ref="FILE-LOCALHOST" />
         </logger>
+        <root level="INFO">
+            <appender-ref ref="CONSOLE" />
+        </root>
+    </configuration>
+
+Alternatively, you can use bundled Logstash encoder for logging in JSON format:
+
+    <configuration>
+        <appender name="CONSOLE" class="org.apache.juli.logging.ch.qos.logback.core.ConsoleAppender">
+            <encoder class="org.apache.juli.logging.net.logstash.logback.encoder.LogstashEncoder" />
+        </appender>
         <root level="INFO">
             <appender-ref ref="CONSOLE" />
         </root>

--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,10 @@
         <!-- Override for Latest Versions -->
         <logback.version>1.4.8</logback.version>
         <slf4j.version>2.0.7</slf4j.version>
+        
+        <!-- Logstash Encoder and deps versions -->
+        <logstash.version>7.4</logstash.version>
+        <jackson.version>2.15.2</jackson.version>
     </properties>
 
     <dependencies>
@@ -75,6 +79,30 @@
             <groupId>org.apache.tomcat</groupId>
             <artifactId>tomcat-juli</artifactId>
             <version>${tomcat.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>net.logstash.logback</groupId>
+            <artifactId>logstash-logback-encoder</artifactId>
+            <version>${logstash.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>${jackson.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <version>${jackson.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${jackson.version}</version>
             <optional>true</optional>
         </dependency>
     </dependencies>
@@ -127,6 +155,10 @@
                                     <include>org.slf4j:slf4j-api</include>
                                     <include>ch.qos.logback:logback-classic</include>
                                     <include>ch.qos.logback:logback-core</include>
+                                    <include>com.fasterxml.jackson.core:jackson-core</include>
+                                    <include>com.fasterxml.jackson.core:jackson-databind</include>
+                                    <include>com.fasterxml.jackson.core:jackson-annotations</include>
+                                    <include>net.logstash.logback:logstash-logback-encoder</include>
                                 </includes>
                             </artifactSet>
 
@@ -187,6 +219,23 @@
                                         <exclude>module-info.*</exclude>
                                     </excludes>
                                 </filter>
+
+                                <filter>
+                                    <artifact>com.fasterxml*:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/MANIFEST.MF</exclude>
+                                        <exclude>META-INF/NOTICE</exclude>
+                                        <exclude>META-INF/LICENSE</exclude>
+                                        <exclude>META-INF/versions/9/module-info.class</exclude>
+                                    </excludes>
+                                </filter>
+
+                                <filter>
+                                    <artifact>net.logstash.logback:logstash-logback-encoder</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/MANIFEST.MF</exclude>
+                                    </excludes>
+                                </filter>
                             </filters>
 
                             <relocations>
@@ -213,6 +262,16 @@
                                 <relocation>
                                     <pattern>logback.ContextSelector</pattern>
                                     <shadedPattern>juli-logback.ContextSelector</shadedPattern>
+                                </relocation>
+
+                                <relocation>
+                                    <pattern>com.fasterxml</pattern>
+                                    <shadedPattern>org.apache.juli.logging.com.fasterxml</shadedPattern>
+                                </relocation>
+
+                                <relocation>
+                                    <pattern>net.logstash.logback</pattern>
+                                    <shadedPattern>org.apache.juli.logging.net.logstash.logback</shadedPattern>
                                 </relocation>
                             </relocations>
 


### PR DESCRIPTION
Extending this project with ability to log in JSON format via [logstash-logback-encoder](https://github.com/logfellow/logstash-logback-encoder).

Added dependencies:
- net.logstash.logback:logstash-logback-encoder
- com.fasterxml.jackson.core:jackson-core
- com.fasterxml.jackson.core:jackson-annotations
- com.fasterxml.jackson.core:jackson-databind